### PR TITLE
Add config_path helper function for Lumen

### DIFF
--- a/src/Mayconbordin/L5Mustache/L5MustacheServiceProvider.php
+++ b/src/Mayconbordin/L5Mustache/L5MustacheServiceProvider.php
@@ -18,7 +18,7 @@ class L5MustacheServiceProvider extends ServiceProvider {
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../../config/config.php' => config_path('l5-mustache.php')
+	        __DIR__ . '/../../config/config.php' => function_exists('config_path') ? config_path('l5-mustache.php') : self::config_path('l5-mustache.php')
         ]);
 
         $this->mergeConfigFrom(
@@ -59,6 +59,18 @@ class L5MustacheServiceProvider extends ServiceProvider {
 	public function provides()
 	{
 		return ['l5-mustache'];
+	}
+
+	/**
+	 * Helper function, since config_path does not exist in Lumen
+	 *
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	static function config_path($path = '')
+	{
+		return app()->basePath() . '/config' . ($path ? '/' . $path : $path);
 	}
 
 }


### PR DESCRIPTION
I tried this with my Lumen app but it wasn't working because `config_path()` doesn't exist in the latest version of Lumen. So I made a quick wrapper for it based on https://gist.github.com/mabasic/21d13eab12462e596120

Now Mustache templates work great with my Lumen app.

I hope you can merge it so we can switch back to using your version!
