### PR TITLE
Fix error in Lumen 5.5

### DIFF
--- a/src/Mayconbordin/L5Mustache/MustacheEngine.php
+++ b/src/Mayconbordin/L5Mustache/MustacheEngine.php
@@ -1,6 +1,6 @@
 <?php namespace Mayconbordin\L5Mustache;
 
-use Illuminate\View\Engines\EngineInterface;
+use Illuminate\Contracts\View\Engine as EngineInterface;
 use Illuminate\Filesystem\Filesystem;
 use Mustache_Engine;
 


### PR DESCRIPTION
Without this fix, the following error is displayed in Lumen 5.5:

```
Fatal error: Interface 'Illuminate\View\Engines\EngineInterface' not found
```